### PR TITLE
Add a way to customize segment name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ Devel::KYTProf::Logger::XRay is a logger for AWS::XRay.
 
 See also [AWS::XRay](https://metacpan.org/pod/AWS%3A%3AXRay).
 
+# CONFIGURATION
+
+## segment\_name\_builder
+
+Code ref to generate custom segment name.
+
+Passed `%args` that from `log` method taken.
+
+    Devel::KYTProf::Logger::XRay->new(segment_name_builder => sub {
+        my (%args) = @_;
+        return 'seg:' . $args{module};
+    });
+
 # LICENSE
 
 Copyright (C) FUJIWARA Shunichiro.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ Devel::KYTProf::Logger::XRay - Logger for AWS::XRay
 # SYNOPSIS
 
     use Devel::KYTProf::Logger::XRay;
-    Devel::KYTProf->logger("Devel::KYTProf::Logger::XRay");
+    my $logger = Devel::KYTProf::Logger::XRay->new;
+    Devel::KYTProf->logger($logger);
 
 # DESCRIPTION
 
 Devel::KYTProf::Logger::XRay is a logger for AWS::XRay.
 
-See also [AWS::XRay](https://metacpan.org/pod/AWS::XRay).
+See also [AWS::XRay](https://metacpan.org/pod/AWS%3A%3AXRay).
 
 # LICENSE
 

--- a/lib/Devel/KYTProf/Logger/XRay.pm
+++ b/lib/Devel/KYTProf/Logger/XRay.pm
@@ -9,8 +9,13 @@ use Time::HiRes();
 
 our $VERSION = "0.04";
 
+sub new {
+    my ($class) = @_;
+    return bless {}, $class;
+}
+
 sub log {
-    my ($class, %args) = @_;
+    my ($self, %args) = @_;
 
     return if !$AWS::XRay::ENABLED;
 
@@ -55,7 +60,8 @@ Devel::KYTProf::Logger::XRay - Logger for AWS::XRay
 =head1 SYNOPSIS
 
     use Devel::KYTProf::Logger::XRay;
-    Devel::KYTProf->logger("Devel::KYTProf::Logger::XRay");
+    my $logger = Devel::KYTProf::Logger::XRay->new;
+    Devel::KYTProf->logger($logger);
 
 =head1 DESCRIPTION
 

--- a/t/01_log.t
+++ b/t/01_log.t
@@ -34,7 +34,8 @@ Devel::KYTProf->add_prof(
     },
 );
 
-Devel::KYTProf->logger("Devel::KYTProf::Logger::XRay");
+my $logger = Devel::KYTProf::Logger::XRay->new;
+Devel::KYTProf->logger($logger);
 
 {
     local $AWS::XRay::TRACE_ID = AWS::XRay::new_trace_id();


### PR DESCRIPTION
Recently `database => $dbh->{Name}` is introduced to Devel::KYTProf::Profiler::DBI.
see https://github.com/onishi/perl5-devel-kytprof/pull/23

This PR introduces a way to customize segment name, so now we can add connected database name to the segment and distinct traces that communicate with multiple databases.